### PR TITLE
improved error handling when password change fails

### DIFF
--- a/ws_validator.js
+++ b/ws_validator.js
@@ -28,6 +28,7 @@ var PasswordExpired = require('./lib/errors/PasswordExpired');
 var WrongPassword = require('./lib/errors/WrongPassword');
 var WrongUsername = require('./lib/errors/WrongUsername');
 var InsufficientAccessRightsError = require('./lib/errors/InsufficientAccessRightsError');
+var PasswordComplexityError = require('./lib/errors/PasswordComplexityError');
 
 ws.sendEvent = function (name, payload) {
   this.send(JSON.stringify({
@@ -263,7 +264,15 @@ if (nconf.get('ENABLE_WRITE_BACK')) {
         if (err) {
           if (err instanceof InsufficientAccessRightsError) {
             log("Change Password attempt failed. Reason: " + "Service account has Insufficient Access Rights".red);
-            return ws.reply(payload.pid + '_change_password_result', {
+            return ws.sendEvent(payload.pid + '_change_password_result', {
+              err: err,
+              profile: err.profile
+            });
+          }
+
+          if (err instanceof PasswordComplexityError) {
+            log("Change Password attempt failed. Reason: " + "Password password doesn’t meet minimum requirements".red);
+            return ws.sendEvent(payload.pid + '_change_password_result', {
               err: err,
               profile: err.profile
             });


### PR DESCRIPTION
Return the error `PasswordComplexityError`. 
Fix issue where error was not pushed back to `auth0-users` so no response was returned to the client.